### PR TITLE
Raise default truncate max_length

### DIFF
--- a/history/storage.py
+++ b/history/storage.py
@@ -98,7 +98,7 @@ def _truncate_metadata_fields(metadata, max_length=400):
     return truncated_fields
 
 
-def _truncate_url(url, max_length=200):
+def _truncate_url(url, max_length=900):
     return (url[:max_length] + '...' if len(url) > max_length else url)
 
 


### PR DESCRIPTION
S3 has a key limit of 1024 bytes. Raise sensibly the URL truncation limit so it can store full URLs and still have leeway for S3 key prefix.

Relevant S3 documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys